### PR TITLE
Fix level_limit being ignored in multilevel_partition

### DIFF
--- a/src/disqco/parti/partitioner.py
+++ b/src/disqco/parti/partitioner.py
@@ -101,8 +101,9 @@ class QuantumCircuitPartitioner:
         # Extract coarsener-related kwargs
         coarsener_kwargs = {}
         for key in list(kwargs.keys()):
-            if key in ['num_levels',  'num_blocks', 'block_size', 'recursion_factor']:
+            if key in ['num_levels', 'num_blocks', 'block_size', 'recursion_factor']:
                 coarsener_kwargs[key] = kwargs.pop(key)
+        level_limit = kwargs.pop('level_limit', 100)
 
         graph = kwargs.get('graph', self.hypergraph)
         graph_list, mapping_list = coarsener(hypergraph=graph, **coarsener_kwargs)
@@ -113,7 +114,6 @@ class QuantumCircuitPartitioner:
             assignment = self.initial_assignment.copy()
         else:
             assignment = None
-        level_limit = coarsener_kwargs.get('level_limit', 100)
         list_of_assignments = []
         list_of_costs = []
         best_cost = float('inf')

--- a/tests/test_multilevel_partitioning.py
+++ b/tests/test_multilevel_partitioning.py
@@ -131,6 +131,45 @@ def test_multilevel_partition_returns_cost_list(test_circuit, test_network):
     print(f"\nCost progression: {results['cost_list']}")
 
 
+def test_level_limit_is_honored(test_circuit, test_network):
+    """Regression test: level_limit must cap the number of levels processed.
+
+    Before the fix, level_limit was never copied into coarsener_kwargs so the
+    lookup `coarsener_kwargs.get('level_limit', 100)` always returned 100,
+    making the argument a no-op.  After the fix, passing level_limit=2 must
+    result in exactly 2 entries in assignment_list / cost_list.
+    """
+    partitioner = FiducciaMattheyses(test_circuit, test_network)
+    coarsener = HypergraphCoarsener().coarsen_recursive_batches_mapped
+
+    results = partitioner.multilevel_partition(
+        coarsener=coarsener,
+        passes_per_level=3,
+        level_limit=2,
+    )
+
+    assert len(results['assignment_list']) == 2, (
+        f"Expected 2 levels (level_limit=2) but got {len(results['assignment_list'])}"
+    )
+    assert len(results['cost_list']) == 2, (
+        f"Expected 2 cost entries (level_limit=2) but got {len(results['cost_list'])}"
+    )
+
+    # Confirm an unrestricted run produces more than 2 levels, proving the
+    # coarsener actually generates >2 levels for this circuit.
+    partitioner2 = FiducciaMattheyses(test_circuit, test_network)
+    results_full = partitioner2.multilevel_partition(
+        coarsener=coarsener,
+        passes_per_level=3,
+    )
+    assert len(results_full['assignment_list']) > 2, (
+        "Unrestricted run produced <=2 levels; level_limit=2 test is not meaningful"
+    )
+
+    print(f"\nlevel_limit=2 → {len(results['assignment_list'])} level(s) processed")
+    print(f"Unrestricted   → {len(results_full['assignment_list'])} level(s) processed")
+
+
 def test_single_level_partition_for_comparison(test_circuit, test_network):
     """Test single-level (no coarsening) partition for comparison"""
     partitioner = FiducciaMattheyses(test_circuit, test_network)


### PR DESCRIPTION
## Summary

- `level_limit` was accepted as a kwarg by `multilevel_partition` but never moved into `coarsener_kwargs`, so `coarsener_kwargs.get('level_limit', 100)` always returned the default `100` — making the argument a silent no-op
- Fix: pop `level_limit` directly from `kwargs` before the coarsener call, keeping it out of `coarsener_kwargs` (which is forwarded to the coarsener function that does not accept `level_limit`)
- Adds a regression test that would have caught this bug: calls `multilevel_partition(level_limit=2)` and asserts `len(assignment_list) == 2`

## Test plan

- [x] `pytest tests/test_multilevel_partitioning.py::test_level_limit_is_honored -v` — new regression, must pass
- [x] `pytest tests/test_multilevel_partitioning.py -v` — full suite, no regressions
